### PR TITLE
feat: initData 생성 및 ChatTitle 기능 구현 (헤더위주)

### DIFF
--- a/src/components/ChatTitle.jsx
+++ b/src/components/ChatTitle.jsx
@@ -17,6 +17,9 @@ const ChatTitle = ({ isHeader = false }) => {
   // 현재 선택된 세션 찾아서 currentSession에 저장
   const currentSession = chatSessions.find((session) => session.id === currentSessionId);
 
+  // 타이틀 설정되어있는지 확인
+  const isPlaceholder = currentSession.title === '제목을 입력해주세요.';
+
   // 제목이 바뀌면 inputValue도 초기화
   useEffect(() => {
     setInputValue(currentSession.title);
@@ -56,7 +59,7 @@ const ChatTitle = ({ isHeader = false }) => {
   return (
     <div
       className={`
-    flex items-center gap-[10px] text-[16px] leading-[1] text-gray/80 font-medium
+    flex items-center gap-[10px] text-[16px] leading-[1] ${isPlaceholder ? 'text-gray/80' : 'text-gray'} font-medium
     px-[16px] py-[7px] rounded-[10px]
     max-w-[250px]
     cursor-pointer
@@ -79,7 +82,9 @@ const ChatTitle = ({ isHeader = false }) => {
           onKeyDown={handleKeyDown}
         />
       ) : (
-        <span className="text-[16px] leading-[1] text-gray/80 font-medium truncate">
+        <span
+          className={`text-[16px] leading-[1] ${isPlaceholder ? 'text-gray/80' : 'text-gray'} font-medium truncate`}
+        >
           {currentSession.title}
         </span>
       )}

--- a/src/components/ChatTitle.jsx
+++ b/src/components/ChatTitle.jsx
@@ -61,7 +61,7 @@ const ChatTitle = ({ isHeader = false }) => {
       className={`
     flex items-center gap-[10px] text-[16px] leading-[1] ${isPlaceholder ? 'text-gray/80' : 'text-gray'} font-medium
     px-[16px] py-[7px] rounded-[10px]
-    max-w-[250px]
+    max-w-[1000px]
     cursor-pointer
     hover:bg-gray-stroke03
     transition-all duration-150 ease-in-out
@@ -73,9 +73,11 @@ const ChatTitle = ({ isHeader = false }) => {
         <input
           ref={inputRef}
           type="text"
-          className="w-full max-w-[250px] bg-transparent border-none outline-none
+          className=" w-auto min-w-[30px] max-w-[1000px]
+          bg-transparent border-none outline-none
           focus:outline-none focus:ring-0
           text-[16px] leading-[1] text-gray/80 font-medium truncat"
+          style={{ width: `${Math.max(inputValue.length * 13 + 15, 60)}px` }} // 길이에 따라 유동
           value={inputValue}
           onChange={(e) => setInputValue(e.target.value)}
           onBlur={handleSave}
@@ -83,7 +85,7 @@ const ChatTitle = ({ isHeader = false }) => {
         />
       ) : (
         <span
-          className={`text-[16px] leading-[1] ${isPlaceholder ? 'text-gray/80' : 'text-gray'} font-medium truncate`}
+          className={`w-auto text-[16px] leading-[1] ${isPlaceholder ? 'text-gray/80' : 'text-gray'} font-medium truncate`}
         >
           {currentSession.title}
         </span>

--- a/src/components/ChatTitle.jsx
+++ b/src/components/ChatTitle.jsx
@@ -56,6 +56,25 @@ const ChatTitle = ({ isHeader = false }) => {
     }
   };
 
+  // 너비 계산 함수
+  const calculateInputWidth = (text) => {
+    let width = 0;
+    for (let char of text) {
+      if (/[ㄱ-ㅎㅏ-ㅣ가-힣]/.test(char)) {
+        width += 13; // 한글
+      } else if (/[A-Z]/.test(char)) {
+        width += 10; // 영어 대문자
+      } else if (/[a-z]/.test(char)) {
+        width += 8; // 영어 소문자
+      } else if (/\d/.test(char)) {
+        width += 9; // 숫자
+      } else {
+        width += 10; // 특수문자 등 기타
+      }
+    }
+    return Math.max(width + 20, 60); // 여유 패딩 + 최소 너비 보장
+  };
+
   return (
     <div
       className={`
@@ -77,7 +96,7 @@ const ChatTitle = ({ isHeader = false }) => {
           bg-transparent border-none outline-none
           focus:outline-none focus:ring-0
           text-[16px] leading-[1] text-gray/80 font-medium truncat"
-          style={{ width: `${Math.max(inputValue.length * 13 + 15, 60)}px` }} // 길이에 따라 유동
+          style={{ width: `${calculateInputWidth(inputValue)}px` }} //입력된 글자에 따라 길이 유동적으로
           value={inputValue}
           onChange={(e) => setInputValue(e.target.value)}
           onBlur={handleSave}

--- a/src/components/ChatTitle.jsx
+++ b/src/components/ChatTitle.jsx
@@ -1,12 +1,30 @@
+import { useContext } from 'react';
+import { ChatContext } from '../contexts/ChatContext';
+
+// 헤더용
 import { IconEdit } from '../utils/icons';
-const ChatTitle = () => {
+/**
+ * @param {boolean} isHeader - Header에서 사용하는 경우 true (수정 아이콘 표시)
+ */
+
+// 기본값 false (헤더에서 안 쓸 애임)
+const ChatTitle = ({ isHeader = false }) => {
+  // 전체 세션과 현재 사용자가 선택한 세션 가져옴
+  const { chatSessions, currentSessionId } = useContext(ChatContext);
+
+  // 현재 선택된 세션 찾아서 currentSession에 저장
+  const currentSession = chatSessions.find((session) => session.id === currentSessionId);
+  // 선택된 세션이 없을 경우 예외 처리 (ChatTitle 나오지 않음)
+  if (!currentSession) return null;
   return (
-    <div className="flex gap-[10px]">
-      {/* header 기준 css */}
-      <div className="text-base text-gray/50 font-medium max-w-[250px]">제목을 입력해 주세요.</div>
-      {/* 조건부 */}
-      <img className="w-[12px] h-auto" src={IconEdit} alt="수정 아이콘" />
+    <div className="flex gap-[10px] items-center">
+      <div className="text-base text-gray/50 font-medium max-w-[250px] truncate">
+        {currentSession.title}
+      </div>
+      {/* Header일 경우에만 수정 아이콘 표시 */}
+      {isHeader === true && <img className="w-[12px] h-auto" src={IconEdit} alt="수정 아이콘" />}
     </div>
   );
 };
+
 export default ChatTitle;

--- a/src/components/ChatTitle.jsx
+++ b/src/components/ChatTitle.jsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import { useContext, useState, useEffect, useRef } from 'react';
 import { ChatContext } from '../contexts/ChatContext';
 
 // 헤더용
@@ -10,19 +10,92 @@ import { IconEdit } from '../utils/icons';
 // 기본값 false (헤더에서 안 쓸 애임)
 const ChatTitle = ({ isHeader = false }) => {
   // 전체 세션과 현재 사용자가 선택한 세션 가져옴
-  const { chatSessions, currentSessionId } = useContext(ChatContext);
-
+  const { chatSessions, currentSessionId, setChatSessions } = useContext(ChatContext);
+  const [isEditing, setIsEditing] = useState(false);
+  const [inputValue, setInputValue] = useState('');
+  const inputRef = useRef(null);
   // 현재 선택된 세션 찾아서 currentSession에 저장
   const currentSession = chatSessions.find((session) => session.id === currentSessionId);
+
+  // 제목이 바뀌면 inputValue도 초기화
+  useEffect(() => {
+    setInputValue(currentSession.title);
+  }, [currentSession.title]);
+
+  // input에 포커스 주기
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [isEditing]);
+
   // 선택된 세션이 없을 경우 예외 처리 (ChatTitle 나오지 않음)
   if (!currentSession) return null;
+
+  // 저장 함수
+  const handleSave = () => {
+    const trimmed = inputValue.trim();
+    if (trimmed === '') return; // 빈 값은 저장 안 함
+    setChatSessions((prev) =>
+      prev.map((session) =>
+        session.id === currentSessionId ? { ...session, title: trimmed } : session
+      )
+    );
+    setIsEditing(false);
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter') {
+      handleSave();
+    } else if (e.key === 'Escape') {
+      setIsEditing(false); // ESC 눌렀을 때 취소
+      setInputValue(currentSession.title); // 원래 제목 복원
+    }
+  };
+
   return (
-    <div className="flex gap-[10px] items-center">
-      <div className="text-base text-gray/50 font-medium max-w-[250px] truncate">
-        {currentSession.title}
-      </div>
-      {/* Header일 경우에만 수정 아이콘 표시 */}
-      {isHeader === true && <img className="w-[12px] h-auto" src={IconEdit} alt="수정 아이콘" />}
+    <div
+      className={`
+    flex items-center gap-[10px] text-[16px] leading-[1] text-gray/80 font-medium
+    px-[16px] py-[7px] rounded-[10px]
+    max-w-[250px]
+    cursor-pointer
+    hover:bg-gray-stroke03
+    transition-all duration-150 ease-in-out
+  `}
+      onDoubleClick={() => setIsEditing(true)}
+    >
+      {/* 텍스트 부분만 수정 가능 */}
+      {isEditing ? (
+        <input
+          ref={inputRef}
+          type="text"
+          className="w-full max-w-[250px] bg-transparent border-none outline-none
+          focus:outline-none focus:ring-0
+          text-[16px] leading-[1] text-gray/80 font-medium truncat"
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          onBlur={handleSave}
+          onKeyDown={handleKeyDown}
+        />
+      ) : (
+        <span className="text-[16px] leading-[1] text-gray/80 font-medium truncate">
+          {currentSession.title}
+        </span>
+      )}
+
+      {/* 아이콘은 항상 유지 */}
+      {isHeader && (
+        <img
+          src={IconEdit}
+          alt="수정 아이콘"
+          className="w-[12px] h-auto cursor-pointer"
+          onClick={(e) => {
+            e.stopPropagation();
+            setIsEditing(true);
+          }}
+        />
+      )}
     </div>
   );
 };

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,3 +1,6 @@
+import { useContext } from 'react';
+import { ChatContext } from '../contexts/ChatContext';
+
 import SidebarToggleButton from './Header/SidebarToggleButton';
 import ChatTitle from './ChatTitle';
 import FilterButton from './Header/FilterButton';
@@ -5,6 +8,8 @@ import SummaryButton from './Header/SummaryButton';
 import HeaderProfile from './Header/HeaderProfile';
 
 const Header = () => {
+  const { currentSessionId } = useContext(ChatContext);
+
   return (
     <div className="fixed top-0 left-0 w-full h-[60px] bg-white z-50 border-b border-gray-900/5">
       <div className="max-w-[1440px] mx-auto flex items-center justify-between h-full px-[20px]">
@@ -14,7 +19,9 @@ const Header = () => {
         </div>
         {/* 조건부렌더링 */}
         <div className="flex w-full mx-auto items-center justify-between px-[42px]">
-          <ChatTitle />
+          {/* currentSessionId가 있을 때만 ChatTitle 보여줌 */}
+          {currentSessionId && <ChatTitle isHeader={true} />}
+
           {/* <div className="flex ml-auto gap-[16px]">
           <FilterButton />
           <SummaryButton />

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -12,7 +12,7 @@ const Header = () => {
 
   return (
     <div className="fixed top-0 left-0 w-full h-[60px] bg-white z-50 border-b border-gray-900/5">
-      <div className="max-w-[1440px] mx-auto flex items-center justify-between h-full px-[20px]">
+      <div className="max-w-[1440px] mx-auto flex items-center justify-between h-full">
         {/* 왼쪽 버튼 */}
         <div className="px-[20px]">
           <SidebarToggleButton />

--- a/src/contexts/ChatContext.jsx
+++ b/src/contexts/ChatContext.jsx
@@ -38,10 +38,10 @@ const initData = [
 ];
 export const ChatProvider = ({ children }) => {
   // 모든 대화 세션(채팅방)을 저장하는 배열
-  const [chatSessions, setChatSessions] = useState([initData[0].id]);
+  const [chatSessions, setChatSessions] = useState(initData);
 
   // 지금 사용자가 보고 있는 대화의 ID, 사이드바에서 대화를 클릭하면 이 값이 바뀜
-  const [currentSessionId, setCurrentSessionId] = useState(null);
+  const [currentSessionId, setCurrentSessionId] = useState(initData[0].id);
 
   // ❌ 사이드바/헤더에선 사용하지 않음
   // 챗봇 응답 기다리는 중인지 아닌지 판단
@@ -126,6 +126,7 @@ export const ChatProvider = ({ children }) => {
         createChatSession,
         setCurrentSessionId,
         toggleBookmark,
+        setChatSessions,
 
         // ❌ 사이드바/헤더에선 사용하지 않음
         // isLoading,

--- a/src/contexts/ChatContext.jsx
+++ b/src/contexts/ChatContext.jsx
@@ -7,10 +7,39 @@ import { createContext, useState } from 'react';
 import { v4 as uuidv4 } from 'uuid'; // UUID 생성용 (npm install uuid) ✨
 
 export const ChatContext = createContext();
-
+const initData = [
+  {
+    id: uuidv4(),
+    title: '지성 피부용 선크림 추천',
+    mode: 'product_detail',
+    skin_type: '지성',
+    is_bookmark: true,
+    created_at: '2024-04-01T12:00:00Z',
+    messages: [],
+  },
+  {
+    id: uuidv4(),
+    title: '트러블 케어 제품 문의',
+    mode: 'product_detail',
+    skin_type: '복합성',
+    is_bookmark: false,
+    created_at: '2024-04-02T09:30:00Z',
+    messages: [],
+  },
+  {
+    id: uuidv4(),
+    title: '건성 피부 스킨 루틴',
+    mode: 'product_detail',
+    skin_type: '건성',
+    is_bookmark: false,
+    created_at: '2024-04-03T18:45:00Z',
+    messages: [],
+  },
+];
 export const ChatProvider = ({ children }) => {
   // 모든 대화 세션(채팅방)을 저장하는 배열
-  const [chatSessions, setChatSessions] = useState([]);
+  const [chatSessions, setChatSessions] = useState([initData[0].id]);
+
   // 지금 사용자가 보고 있는 대화의 ID, 사이드바에서 대화를 클릭하면 이 값이 바뀜
   const [currentSessionId, setCurrentSessionId] = useState(null);
 


### PR DESCRIPTION
<!--
[제목]
작업: 회원 가입 기능 구현
-->

## 🔗 관련 이슈

<!--
ex) #12
-->
#31 
## 📌 작업 내용

<!--
- 어떤 작업을 했는지 간단히 요약해주세요
- 예: 로그인 기능 API 연동
-->
initData 생성 (Header에서 필요한 정보만)
chatSessionId로 현재 선택한 창의 title 불러오기 및 수정 후 저장 (로컬상태에서만)
더블클릭 시 수정, 외부 혹은 엔터 시 수정완료, ESC시 취소, 빈 값은 저장 안 함
chatSessionId가 없을 경우에는 ChatTitle자체를 불러오지X (예외처리)
isHeader를 props로 전달하여, true인 경우에만 EditIcon까지 렌더링

title이 우리가 넣어준 기본값(제목을 입력해주세요.)와 같으면 제목을 지정하지 않았다고 가정하고 text색 gray/80, 다르면 gray/100

## 👀 특히 봐줬으면 하는 부분

<!--
- 리뷰어가 특히 봐줬으면 하는 부분이 있다면 적어주세요
- 예: 변수명 괜찮은지 봐주세요 / 조건문 로직이 자연스러운지 확인 부탁드려요 등
-->

- 버튼 수정하려고 누르면 hover시와 같은 UI 디자인을 적용하는게 맞죠?
- 타이틀 수정 시에 뒷배경이 자동으로 늘어나있는데 고치는방법을 찾지못했으나 나름그럴싸해보여서(? 냅둠
-

## 📚 참고 자료

<!--
- https://example.com/signup-api (회원 가입 API 설계서)
- https://example.com/bcrypt (Spring Security BCryptPasswordEncoder 사용법)
-->

## ✅ 작성자 체크리스트

- [✅ ] 코드가 정상적으로 컴파일되나요?
- [✅ ] merge할 브랜치의 위치를 확인했나요?
